### PR TITLE
CI/CD: Update the buld script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.tex"
 
 jobs:
   build:
@@ -27,7 +29,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-AKR
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-DAK
         uses: xu-cheng/latex-action@v2
@@ -35,7 +36,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-DAK
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-HWS
         uses: xu-cheng/latex-action@v2
@@ -43,7 +43,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-HWS
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-IC2
         uses: xu-cheng/latex-action@v2
@@ -51,7 +50,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-IC2
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-KKR
         uses: xu-cheng/latex-action@v2
@@ -59,7 +57,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-KKR
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-KOM
         uses: xu-cheng/latex-action@v2
@@ -67,7 +64,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-KOM
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-MDS
         uses: xu-cheng/latex-action@v2
@@ -75,7 +71,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-MDS
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-PNA
         uses: xu-cheng/latex-action@v2
@@ -83,7 +78,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-PNA
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-SOS
         uses: xu-cheng/latex-action@v2
@@ -91,7 +85,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-SOS
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-SPR
         uses: xu-cheng/latex-action@v2
@@ -99,7 +92,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-SPR
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-TIN
         uses: xu-cheng/latex-action@v2
@@ -107,7 +99,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-TIN
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-UP2A
         uses: xu-cheng/latex-action@v2
@@ -115,7 +106,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-UP2A
           root_file: main.tex
-        if: ${{ always() }}
 
       - name: Build BPC-ZSY
         uses: xu-cheng/latex-action@v2
@@ -123,7 +113,6 @@ jobs:
           latexmk_shell_escape: true
           working_directory: BPC-ZSY
           root_file: main.tex
-        if: ${{ always() }}
 
       # Prepare tag name
       - name: Create tag
@@ -131,7 +120,6 @@ jobs:
         run: |
           tag=build-$(date +%Y%m%d-%H%M%S)
           echo "::set-output name=tag::$tag"
-        if: ${{ always() }}
 
       # Create release draft, so we can add the files
       - name: Create draft release


### PR DESCRIPTION
- Only run the build if any .tex file is changed
- Remove the always() conditions

Yesterday the build failed when it encountred error in BPC-SOS. I think it would be better if we knew that there is some error in the package, instead of investigating the build logs. By using `always()` everywhere we're abusing the build logic a bit, which is not ideal.