### PR TITLE
Formatting, Typos, Switch to LaTeX mathmode instead of TeX mathmode for BPC-TIN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.log
 *.out
 *.synctex.gz
+*.synctex(busy)
 *.toc
 # Cache directories
 **/cache*

--- a/BPC-DAK/main.tex
+++ b/BPC-DAK/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-HWS/main.tex
+++ b/BPC-HWS/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-IC2/main.tex
+++ b/BPC-IC2/main.tex
@@ -73,7 +73,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-KKR/main.tex
+++ b/BPC-KKR/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-MDS/main.tex
+++ b/BPC-MDS/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-PNA/main.tex
+++ b/BPC-PNA/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}

--- a/BPC-SOS/text/text.tex
+++ b/BPC-SOS/text/text.tex
@@ -100,8 +100,8 @@ Uživatelský kontext procesu se skládá z~neměnné (statické) části a~dyna
 	\item datová část (data segment) -- Data, která proces potřebuje již od~svého startu, tedy globální proměnné, textové řetězce, datová pole atd.
 	\item halda (\emph{heap}) -- Stromová struktura, kde se mohou dynamicky alokovat data za~běhu programu.
 	\item zásobník (\emph{stack}) -- Také dynamicky alokovaný, ale  ukládají se zde parametry procesem volaných funkcí. Je obvyklé, že zásobník roste směrem k~nižším adresám (tj.~vrchol jde dolů). Jedná se o~LIFO (Last-in First-out) zásobník%
-	\footnote{Mezera mezi haldou a~zásobníkem představuje volné místo, které dovoluje dynamickou změnu zásobníku a~haldy během procesu.}%
-	.
+	      \footnote{Mezera mezi haldou a~zásobníkem představuje volné místo, které dovoluje dynamickou změnu zásobníku a~haldy během procesu.}%
+	      .
 \end{itemize}
 
 \begin{figure}[ht]
@@ -110,9 +110,9 @@ Uživatelský kontext procesu se skládá z~neměnné (statické) části a~dyna
 		\includegraphics[width=\textwidth]{images/proc_user_context.png}
 		\caption{Uživatelský kontext procesu}
 		\label{proc_user_context}
- 	\end{minipage}
-\hspace*{1em}
- 	\begin{minipage}[b]{0.47\textwidth}
+	\end{minipage}
+	\hspace*{1em}
+	\begin{minipage}[b]{0.47\textwidth}
 		\includegraphics[width=\textwidth]{images/proc_data_segment.png}
 		\caption{Datová část paměti procesu}
 		\label{proc_data_segment}
@@ -123,9 +123,9 @@ Datový segment lze rozdělit na:
 
 \begin{itemize}
 	\item inicializovaná data dostupná pouze pro~čtení -- datové prvky inicializované programem,
-	které nelze měnit,
+	      které nelze měnit,
 	\item inicializovaná data dostupná pro~čtení i~zápis -- datové prvky inicializované programem,
-	ovšem jejich hodnoty mohou být za~běhu procesu měněny,
+	      ovšem jejich hodnoty mohou být za~běhu procesu měněny,
 	\item neinicializovaná data -- datové prvky, které program neinicializoval. Neinicializovaná data lze měnit za~běhu procesu.
 \end{itemize}
 
@@ -145,11 +145,11 @@ Jsou zde udržovány informace o~rozložení uživatelského kontextu a~další 
 \begin{table}[ht]
 	\centering
 	\begin{tabular}{l|l}
-	nový       & připraven k~vytvoření \\
-	připravený & proces čeká na~přidělení procesoru \\
-	vykonávaný & instrukce jsou prováděny \\
-	čekající   & proces čeká na~událost (načtení dat) \\
-	ukončený   & proces dokončil vykonávání instrukcí \\
+		nový       & připraven k~vytvoření                \\
+		připravený & proces čeká na~přidělení procesoru   \\
+		vykonávaný & instrukce jsou prováděny             \\
+		čekající   & proces čeká na~událost (načtení dat) \\
+		ukončený   & proces dokončil vykonávání instrukcí \\
 	\end{tabular}
 	\caption{Stavy procesu}
 \end{table}
@@ -303,8 +303,8 @@ Tyto systémy jsou typické pro~nákladná a~výkonná informační centra, kde 
 
 \begin{itemize}
 	\item Výkonnost -- počet úloh zpracovaných za~jednotku času%
-	\footnote{Plánovač zvyšující výkonnost nemusí nutně zvyšovat rychlost obsluhy. Za~účelem zvýšení výkonnosti může upřednostňovat kratší úlohy, na~které se však musí déle čekat. Výkonnost stoupá, ale rychlost obsluhy klesá.}%
-	.
+	      \footnote{Plánovač zvyšující výkonnost nemusí nutně zvyšovat rychlost obsluhy. Za~účelem zvýšení výkonnosti může upřednostňovat kratší úlohy, na~které se však musí déle čekat. Výkonnost stoupá, ale rychlost obsluhy klesá.}%
+	      .
 	\item Rychlost obsluhy -- průměrný čas od~doby přijetí požadavku do~jeho splnění.
 	\item Využití CPU -- preferuje se maximální využití a~minimální prostoje.
 \end{itemize}
@@ -438,7 +438,7 @@ Předešlé metody využívají aktivního čekání, které má následující 
 
 \begin{itemize}
 	\item Plýtvání časem CPU%
-	\footnote{Za~předpokladu, že se nebude čekat moc dlouho, jde využít aktivního čekání.}.
+	      \footnote{Za~předpokladu, že se nebude čekat moc dlouho, jde využít aktivního čekání.}.
 	\item Porušení základní podmínky, že čekání na~vstup do~kritické sekce musí být konečná.
 \end{itemize}
 
@@ -477,11 +477,11 @@ Tato situace lze řešít předcházením uvíznutí, připuštěním že se sys
 
 \begin{itemize}
 	\item Procesy ve~stavu uvíznutí jsou násilně ukončeny:
-	\begin{enumerate}
-		\item postupně -- pomalejší řešení, po~každém ukončeném procesu je potřeba znovu spustit detekční algoritmus, volba procesu může být například na~základě stáří
-		\item všechny najednou -- rychlejší řešení s~velkými náklady (například ztráta předešlých výpočtů a~dat)
-	\end{enumerate}
-	
+	      \begin{enumerate}
+		      \item postupně -- pomalejší řešení, po~každém ukončeném procesu je potřeba znovu spustit detekční algoritmus, volba procesu může být například na~základě stáří
+		      \item všechny najednou -- rychlejší řešení s~velkými náklady (například ztráta předešlých výpočtů a~dat)
+	      \end{enumerate}
+
 	\item Procesům jsou násilně odebrány všechny prostředky a~předávány jiným procesům ve~stavu uvíznutí. Po~každém odebrání je opět potřeba spustit detekční algoritmus, aby se zjistilo zda bylo uvíznutí vyřešeno.
 \end{itemize}
 
@@ -629,8 +629,6 @@ Nedávno používané stránky budou patrně použity znovu a~ty starší pravd�
 
 Jedna z~možností je použití hardware s~64bitovým čítačem, který je inkrementován po~vykonání každé instrukce. Každá stránka má přiděleno jedno návěští kde je hodnota čítače. Po~použití stránky se do~návěští uloží aktuální hodnota čítače. Když je potřeba odstranit stránku je vybrána ta s~nejnižší hodnotou čítače, jelikož byla nižší hodnota čítače znamená, že již proběhlo mnoho instrukcí $\rightarrow$ stará stránka.
 
-\clearpage
-
 Druhá možnost spočívá ve~využití matic (opět v~hardware). Pro~$n$ možných stránek ve~FAP je použita matice $n \times n$ bitů. Při~každém použití stránky $k$ se nastaví bity řádku $k$ na~1 a~poté se vynuluje sloupec $k$. Řádek s~nejnižší binární hodnotu patří stránce nejdéle nepoužité a~je tedy vybrán%
 \footnote{Skripta na~straně 72 mají pěkný příklad.}%
 .
@@ -774,12 +772,12 @@ Do~žurnálu lze ukládat pouze metadata nebo metadata a~vlastní data souboru. 
 
 \begin{itemize}
 	\item Při~ukládání pouze metadat může dojít k~inkonzistenci mezi metadaty. Např. při~přidání dat do~souboru:
-	\begin{enumerate}
-		\item Změna záznamu o~velikosti souboru v~jeho i-uzlu (metadata).
-		\item Z volných datových bloků je vybrán prostor pro~nová data (metadata).
-		\item Do vybraných bloků jsou zapsána data (data).
-	\end{enumerate}
-	Pokud dojde k~pádu systému před třetím krokem, budou v~žurnálu zaznamenány datové bloky, ale v~těch bude náhodná změť paměti.
+	      \begin{enumerate}
+		      \item Změna záznamu o~velikosti souboru v~jeho i-uzlu (metadata).
+		      \item Z volných datových bloků je vybrán prostor pro~nová data (metadata).
+		      \item Do vybraných bloků jsou zapsána data (data).
+	      \end{enumerate}
+	      Pokud dojde k~pádu systému před třetím krokem, budou v~žurnálu zaznamenány datové bloky, ale v~těch bude náhodná změť paměti.
 	\item Při~ukládání s~daty souborů jsou do~žurnálu ukládány kopie všech datových bloků do~kterých se bude zapisovat. Pokud dojde k~pádu, je operace zápisu provedena znovu nad kopií datových bloků. To značně zpomaluje operaci zápisu. Využívá se pouze v~systémech, kde vyžadujeme naprostou ochranu dat.
 \end{itemize}
 
@@ -854,13 +852,13 @@ Spojení může ukončit jakákoliv strana zasláním segmentu s~příznakem FIN
 Správa soketů v~OS Linux se provádí pomocí systémových volání.
 
 \begin{itemize}
-\item \textbf{socket}: Založení nového soketu.
-\item \textbf{connect}: Systémové volání na~straně klienta pro~navázání spojení se soketem na~straně serveru. Navazování spojení probíhá pomocí three-way handshake (viz obrázek \ref{network_three_handshake}).
-\item \textbf{bind}: Přiřadí soketu IP adresu a~port na~straně serveru. Bez~zavolání by byl soket svázán s~náhodným portem z~dynamického rozsahu (49152-65535). U~serveru se ovšem očekává, že bude naslouchat na~portu svázaném se službou (FTP 21, SSH 22, HTTP 80, HTTPS 443, \dots). U~klienta je port generován z~dynamického rozsahu.
-\item \textbf{listen}: Převede soket na~straně serveru do~pasivního režimu kdy přijímá příchozí spojení (pomocí systémového volání accept). Vytvoří se vstupní fronta pro~příchozí spojení.
-\item \textbf{accept}: Voláno na~straně severu k~vyzvednutí požadavku o~spojení ze~vstupní fronty. Volání vytvoří nový soket podle parametrů žádosti o~spojení. Pokud je accept zavolán v~době, kdy je vstupní fronta prázdná, spojení je zablokováno do~doby než žádost přijde.
-\item \textbf{close}: Uzavírá soket. Ukončení spojení zmíněno dříve.
-\item \textbf{write}, \textbf{read}: Systémová volání pro~přenos dat. Data jsou přenášena s~dříve zmíněnými příznaky segmentů PSH a~ACK.
+	\item \textbf{socket}: Založení nového soketu.
+	\item \textbf{connect}: Systémové volání na~straně klienta pro~navázání spojení se soketem na~straně serveru. Navazování spojení probíhá pomocí three-way handshake (viz obrázek \ref{network_three_handshake}).
+	\item \textbf{bind}: Přiřadí soketu IP adresu a~port na~straně serveru. Bez~zavolání by byl soket svázán s~náhodným portem z~dynamického rozsahu (49152-65535). U~serveru se ovšem očekává, že bude naslouchat na~portu svázaném se službou (FTP 21, SSH 22, HTTP 80, HTTPS 443, \dots). U~klienta je port generován z~dynamického rozsahu.
+	\item \textbf{listen}: Převede soket na~straně serveru do~pasivního režimu kdy přijímá příchozí spojení (pomocí systémového volání accept). Vytvoří se vstupní fronta pro~příchozí spojení.
+	\item \textbf{accept}: Voláno na~straně severu k~vyzvednutí požadavku o~spojení ze~vstupní fronty. Volání vytvoří nový soket podle parametrů žádosti o~spojení. Pokud je accept zavolán v~době, kdy je vstupní fronta prázdná, spojení je zablokováno do~doby než žádost přijde.
+	\item \textbf{close}: Uzavírá soket. Ukončení spojení zmíněno dříve.
+	\item \textbf{write}, \textbf{read}: Systémová volání pro~přenos dat. Data jsou přenášena s~dříve zmíněnými příznaky segmentů PSH a~ACK.
 \end{itemize}
 
 \subsection{Serverové procesy}

--- a/BPC-TIN/text/text.tex
+++ b/BPC-TIN/text/text.tex
@@ -39,11 +39,11 @@ Dynamicky se~paměť přiděluje na~základě požadavku při~průběhu programu
 
 \subsubsection{Dynamické přidělování paměti bez~regenerace}
 
-Dynamické přidělovaní paměti bez~regenerace přiděluje požadované úseky postupně tak jak Jsou za~sebou umístěny až do~vyčerpaní vyhrazené paměti. Využívá pracovního ukazatele, který ukazuje na~první adresu volné paměti. Nejčastěji pomocí operace \emph{new} zapíše do~paměti a~změní ukazatel na~novou hodnotu, která ukazuje na~novou adresu volné části a~v indikátoru paměti hodnotu obsazení označí \emph{true}. Operace \emph{free/delete} okamžitě neuvolní paměť, ale přepíše indikátor paměti na~\emph{false}; regenerace probíhá později po~větších částech.
+Dynamické přidělovaní paměti bez~regenerace přiděluje požadované úseky postupně tak jak jsou za~sebou umístěny až do~vyčerpaní vyhrazené paměti. Využívá pracovního ukazatele, který ukazuje na~první adresu volné paměti. Nejčastěji pomocí operace \emph{new} zapíše do~paměti a~změní ukazatel na~novou hodnotu, která ukazuje na~novou adresu volné části a~v indikátoru paměti hodnotu obsazení označí \emph{true}. Operacje \emph{free/delete} okamžitě neuvolní paměť, ale přepíše indikátor paměti na~\emph{false}; regenerace probíhá později po~větších částech.
 
 \subsubsection{Dynamické přidělování paměti s~regenerací}
 
-Na~rozdíl od~dynamického přidělovaní bez~regenerací se~zde regeneruje pro~každé operaci \emph{free/delete}. S~tím přichází problém s~fragmentací paměti. Po~uvolnění paměti by tyto části mohly vytvářet sekvence malých, oddělených a~přitom sousedních prvků. Často je defragmentace těchto volných bloků spojena s~operací \emph{free/delete}. Snaží se~slučovat volné úseky se~sousedními volnými úseky.
+Na~rozdíl od~dynamického přidělovaní bez~regenerace se~zde regeneruje pro~každé operaci \emph{free/delete}. S~tím přichází problém s~fragmentací paměti. Po~uvolnění paměti by tyto části mohly vytvářet sekvence malých, oddělených a~přitom sousedních prvků. Často je defragmentace těchto volných bloků spojena s~operací \emph{free/delete}. Snaží se~slučovat volné úseky se~sousedními volnými úseky.
 
 \subsection{Garbage collector}
 
@@ -68,18 +68,18 @@ Tyto tři fáze se~opakují dokola, pokud nedojde k~situaci, že nový úsek nen
 
 \begin{enumerate}
 	\item Strukturální
-	\begin{enumerate}
-		 \item Diagram tříd
-		 \item Diagram případů užití
-		 \item Diagram komponent
-		 \item Diagram nasazení
-	\end{enumerate}
+	      \begin{enumerate}
+		      \item Diagram tříd
+		      \item Diagram případů užití
+		      \item Diagram komponent
+		      \item Diagram nasazení
+	      \end{enumerate}
 	\item Behaviorální
-	\begin{enumerate}
-		 \item Diagram aktivit
-		 \item Diagram sekvencí
-		 \item Diagram stavů
-	\end{enumerate}
+	      \begin{enumerate}
+		      \item Diagram aktivit
+		      \item Diagram sekvencí
+		      \item Diagram stavů
+	      \end{enumerate}
 \end{enumerate}
 
 Nejpoužívanější jsou diagramy tříd a~případů užití. Diagram tříd popisuje strukturu systému, znázorňuje datové struktury a~operace u~objektů a~souvislosti mezi nimi. Skládá se~z~tříd, rozhraní, abstraktních tříd. Tyto tři prvky se~dále skládají z~názvu třídy/rozhraní, atributů (rozhraní neobsahuje atributy) a~operací (metody/funkce). Diagram případů užití se~nejčastěji používá při~komunikaci se~zákazníkem a~méně technicky znalou stranou. Skládá se~z~herců (\emph{actor}) a~případů užití. Tyto strany jsou propojeny mezi sebou i~samy se~sebou pomocí těchto vztahů: asociace, generalizace, rozšíření vztahu, vztah zahrnuje.
@@ -106,7 +106,7 @@ OON přístup není vhodné využívat pokud na~cílové platformě neexistuje p
 	\caption{Vztahy instancí a~tříd}
 \end{figure}
 
-Násobnost vztahů určuje počet vazeb objektu. \enquote{$1:n$} popisuje jeden objekt s~$n$ referencemi se~kterými je ve~vztahu (faktura $:n$ položek).
+Násobnost vztahů určuje počet vazeb objektu. \enquote{\( 1:n \)} popisuje jeden objekt s~\( n \) referencemi se~kterými je ve~vztahu (faktura \( :n \) položek).
 
 \clearpage
 \section{Třídy složitosti paměťové a~časové. Notace Theta. Notace Omega. Notace velké-O. Asymptotický popis složitosti algoritmu. Posouzení složitosti algoritmů.}
@@ -120,25 +120,25 @@ Násobnost vztahů určuje počet vazeb objektu. \enquote{$1:n$} popisuje jeden 
 Jelikož vždy nelze určit přesnou složitost algoritmu, byla definována asymptotická složitost, která chování funkce aproximuje ze~tří pohledů:
 
 \begin{itemize}
-	\item Nejlepší případ $\Omega$ (Omega) značí spodní hranici trvání algoritmu.
-	\item Průměrný případ $\Theta$ (Theta) odhaduje nejpravděpodobnější dobu trvání algoritmu.
+	\item Nejlepší případ \( \Omega \) (Omega) značí spodní hranici trvání algoritmu.
+	\item Průměrný případ \( \Theta \) (Theta) odhaduje nejpravděpodobnější dobu trvání algoritmu.
 	\item Nejhorší případ O (Omicron, big-O) značí horní hranici trvání algoritmu. Je nejčastěji používaná.
 \end{itemize}
 
 \begin{table}[h]
 	\begin{tabularx}{\textwidth}{|c|c|X|}\hline
-		Konstantní    & O(1)          & Nezávisí na~velikosti vstupních dat \\\hline
+		Konstantní    & O(1)          & Nezávisí na~velikosti vstupních dat                              \\\hline
 		Logaritmická  & O($\log{n}$)  & Náročnost s~velikostí logaritmicky klesáě $10^9 \rightarrow 30$. \\\hline
-		Lineární      & O($n$)        & Počet operací je závislý na~velikosti vstupních dat. \\\hline
-		Kvazilineární & O($n\log{n}$) & Poslední produkčně použitelná náročnost, např. quicksort. \\\hline
-		Kvadratická   & O($n^2$)      & 500 prvků $\rightarrow 250\,000$ operací. \\\hline
-		Kubická       & O($n^3$)      & 200 prvků $\rightarrow 8\,000\,000$ operací. \\\hline
-		Exponenciální & O($2^n$)      & Exponenciální růst počtu operací. \\\hline
-		Faktoriální   & O($n!$)       & Faktoriální růst počtu operací. \\\hline
+		Lineární      & O($n$)        & Počet operací je závislý na~velikosti vstupních dat.             \\\hline
+		Kvazilineární & O($n\log{n}$) & Poslední produkčně použitelná náročnost, např. quicksort.        \\\hline
+		Kvadratická   & O($n^2$)      & 500 prvků $\rightarrow 250\,000$ operací.                        \\\hline
+		Kubická       & O($n^3$)      & 200 prvků $\rightarrow 8\,000\,000$ operací.                     \\\hline
+		Exponenciální & O($2^n$)      & Exponenciální růst počtu operací.                                \\\hline
+		Faktoriální   & O($n!$)       & Faktoriální růst počtu operací.                                  \\\hline
 	\end{tabularx}
 \end{table}
 
-\textbf{Polynomiální algoritmy} jsou takové algoritmy jejichž notace v~big-O je ohraničena polynomiální funkcí shora. Spadají zde například $\log{n}$, $kn$, $3n^3 + 4n$, $2n\log{n}$, naopak sem nepatří exponenciální, faktoriální a~jim podobné. Abychom algoritmus označili jako efektivní, jeho vykonání by mělo být možné v~polynomiálním čase, jinak ho lze označit jako neefektivní. Při~vysokých hodnotách by nepolynomiální algoritmy byly v~kryptografii nepoužitelné.
+\textbf{Polynomiální algoritmy} jsou takové algoritmy jejichž notace v~big-O je ohraničena polynomiální funkcí shora. Spadají zde například \( \log{n} \), \( kn \), \( 3n^3 + 4n \), \( 2n\log{n} \), naopak sem nepatří exponenciální, faktoriální a~jim podobné. Abychom algoritmus označili jako efektivní, jeho vykonání by mělo být možné v~polynomiálním čase, jinak ho lze označit jako neefektivní. Při~vysokých hodnotách by nepolynomiální algoritmy byly v~kryptografii nepoužitelné.
 
 \subsection{Posouzení složitosti algoritmů}
 
@@ -146,15 +146,15 @@ Vybrané algoritmy a~jejich složitost jsou popsány v~dalších otázkách. Zde
 
 \subsubsection{Algoritmy řazení}
 
-Třídění pomocí algoritmů Bubble Sort, Insert Sort a~Select Sort má složitost O($n^2$). Algoritmus Quick Sort má složitost $\Theta$($n\log{n}$)/O($n^2$). Algoritmus Merge Sort má složitost O($n\log{n}$).
+Třídění pomocí algoritmů Bubble Sort, Insert Sort a~Select Sort má složitost O(\( n^2 \)). Algoritmus Quick Sort má složitost \( \Theta \)(\( n\log{n} \))/O(\( n^2 \)). Algoritmus Merge Sort má složitost O(\( n\log{n} \)).
 
 \subsubsection{Algoritmy hledaní}
 
-Binární vyhledávání má složitost O($\log{n}$) a~lineární/sekvenční má složitost O($n$).
+Binární vyhledávání má složitost O(\( \log{n} \)) a~lineární/sekvenční má složitost O(\( n \)).
 
 \subsection{Třídy složitosti}
 
-Vyjadřuje jak náročný je výpočet je nezbytný k~vyřešení problému. \\
+Vyjadřuje, jak náročný je výpočet je nezbytný k~vyřešení problému. \\
 Rozdělení:
 \begin{itemize}
 	\item Třída P\,--\,schůdné algoritmy. Jsou proveditelné v~polynomiálním čase na~deterministickém turingově stroji.
@@ -169,7 +169,7 @@ Rozdělení:
 	\item Univerzální Turingův stroj\,--\,program lze přepsat; dnešní PC, mobily, atd.
 	\item Nedeterministický Turingův stroj\,--\,doposud nesestaven, sestrojení by znamenalo konec asymetrické kryptografie, neví se~jestli ho lze vůbec sestrojit (P vs PN).
 	\item Paralelní Turingův stroj\,-\,z pohledu vyčíslitelnosti je ekvivalentní s~běžným, jen přináší více výkonu.
-	\item Kavantový Turingův stroj\,--\,založen na~superpozicích stavů, dokáže řešit \enquote{exponenciální explozi} a~převést ji na~problém se~složitostí v~polynomiálním čase.
+	\item Kvantový Turingův stroj\,--\,založen na~superpozicích stavů, dokáže řešit \enquote{exponenciální explozi} a~převést ji na~problém se~složitostí v~polynomiálním čase.
 \end{itemize}
 
 \clearpage
@@ -178,7 +178,7 @@ Rozdělení:
 \subsection{Algoritmy hledání}
 
 Dva základní algoritmy pro~hledání jsou \textit{Binary search}%
-\footnote{Binární vyhledávání funguje na~principu půlení seřazeného seznamu. Pokud je hledaná hodnota menší než střední hodnota, vyhledává se v~první polovině, pokud je větší tak v~druhé. Takto se iteruje dokud není číslo nalezeno. Více např. \url{https://en.wikipedia.org/wiki/Binary_search_algorithm}.} %
+\footnote{Binární vyhledávání funguje na~principu půlení seřazeného seznamu. Pokud je hledaná hodnota menší než střední hodnota, vyhledává se v~první polovině, pokud je větší tak v~druhé. Takto se iteruje dokud není číslo nalezeno. Více např. \url{https://www.youtube.com/watch?v=KXJSjte_OAI}.} %
 a~\textit{Linear search}%
 \footnote{Lineární vyhledávání je naprosto jednoduchý lineární průchod seznamem, kde se~postupně hledá požadovaná hodnota. Alternativa je \emph{Linear Sentinel search}, která přidá hledanou hodnotu na~konec seznamu. Více např. \url{https://www.geeksforgeeks.org/linear-search/} nebo \url{https://algorithmoftheweek.blog/2020/06/10/sentinel-linear-search/}.}%
 . Binární funguje lépe než lineární, ale pouze pro~větší a~seřazené seznamy.
@@ -187,9 +187,9 @@ a~\textit{Linear search}%
 	\centering
 	\caption{Big-O složitosti vyhledávacích algoritmů}
 	\begin{tabular}{|c||c|c|}\hline
-		algoritmus           & časová náročnost      & paměťová náročnost \\\hline\hline
-		lineární vyhledávání & O($n$)                & O($1$) \\\hline
-		binární vyhledávání  & O($\log n$)           & O($1$) \\\hline
+		algoritmus           & časová náročnost & paměťová náročnost \\\hline\hline
+		lineární vyhledávání & O(\( n \))       & O(\( 1 \))         \\\hline
+		binární vyhledávání  & O(\( \log n \))  & O(\( 1 \))         \\\hline
 	\end{tabular}
 \end{table}
 
@@ -201,16 +201,16 @@ a~\textit{Linear search}%
 	\centering
 	\caption{Složitost akcí v~lineárních strukturách}
 	\begin{tabular}{|l||c|c|c|c|}\hline
-		struktura             & přidání & vyhledávání & mazání & výběr dle indexu \\\hline\hline
-		pole                  & O($n$)  & O($n$)      & O($n$) & O($1$) \\\hline
-		pole proměnlivé délky & O($1$)  & O($n$)      & O($n$) & O($1$) \\\hline
-		seznam                & O($1$)  & O($n$)      & O($n$) & O($n$) \\\hline
-		zásobník              & O($1$)  & --          & O($1$) & --     \\\hline
-		fronta                & O($1$)  & --          & O($1$) & --     \\\hline
+		struktura             & přidání    & vyhledávání & mazání     & výběr dle indexu \\\hline\hline
+		pole                  & O(\( n \)) & O(\( n \))  & O(\( n \)) & O(\( 1 \))       \\\hline
+		pole proměnlivé délky & O(\( 1 \)) & O(\( n \))  & O(\( n \)) & O(\( 1 \))       \\\hline
+		seznam                & O(\( 1 \)) & O(\( n \))  & O(\( n \)) & O(\( n \))       \\\hline
+		zásobník              & O(\( 1 \)) & --          & O(\( 1 \)) & --               \\\hline
+		fronta                & O(\( 1 \)) & --          & O(\( 1 \)) & --               \\\hline
 	\end{tabular}
 \end{table}
 
-\textbf{Nelineární} jsou například stromy, které, pokud jsou nějak vyvažovány, mají náročnost O($\log{n}$). Pokud se~nevyvažují, náročnost je O($n$). Tyto složitosti jsou pro~všechny operace stejné.
+\textbf{Nelineární} jsou například stromy, které, pokud jsou nějak vyvažovány, mají náročnost O(\( \log{n} \)). Pokud se~nevyvažují, náročnost je O(\( n \)). Tyto složitosti jsou pro~všechny operace stejné.
 
 \subsection{Vztah časové a~paměťové složitosti}
 
@@ -226,13 +226,13 @@ ADT dělíme podle počtu datových položek na~statický a~dynamický datový t
 	\centering
 	\caption{Dělení abstraktních datových typů}
 	\begin{tabular}{|c||c|c|}\hline
-	datový typ & bezprostřední následník & velikost  \\\hline\hline
-	pole       & lineární                & statická  \\\hline
-	seznam     & lineární                & dynamická \\\hline
-	zásobník   & lineární                & dynamická \\\hline
-	fronta     & lineární                & dynamická \\\hline
-	strom      & nelineární              & dynamická \\\hline
-	množina    & nelineární              & dynamická \\\hline
+		datový typ & bezprostřední následník & velikost  \\\hline\hline
+		pole       & lineární                & statická  \\\hline
+		seznam     & lineární                & dynamická \\\hline
+		zásobník   & lineární                & dynamická \\\hline
+		fronta     & lineární                & dynamická \\\hline
+		strom      & nelineární              & dynamická \\\hline
+		množina    & nelineární              & dynamická \\\hline
 	\end{tabular}
 \end{table}
 
@@ -260,11 +260,11 @@ ADT lineární seznam je seznam, kde každý uzel má unikátního následníka.
 
 \subsubsection{Operace s~ADT seznamem}
 
-Nalezení délky, výpis všech prvků, získání $n$-tého prvku, vložení nového prvku za $k$-tý prvek, smazání prvku, nalezení předcházejícího a~následujícího prvku.
+Nalezení délky, výpis všech prvků, získání \( n \)-tého prvku, vložení nového prvku za \( k \)-tý prvek, smazání prvku, nalezení předcházejícího a~následujícího prvku.
 
-Pro~\textbf{vložení} prvku je nejprve nalezena pozice mezi prvky existujícími: $k$. Ukazatel $k-1$ prvku je přepsán na $k$-tý a~ukazatel nového ($k$-tého) prvku je přepsán na~$k+1$, na~který původně ukazoval $k-1$. Operace fungují stejně, jen jsou vázány na~obě strany (viz obrázek~\ref{sezins}).
+Pro~\textbf{vložení} prvku je nejprve nalezena pozice mezi prvky existujícími: \( k \). Ukazatel \( k-1 \) prvku je přepsán na \( k \)-tý a~ukazatel nového (\( k \)-tého) prvku je přepsán na~\( k+1 \), na~který původně ukazoval \( k-1 \). Operace fungují stejně, jen jsou vázány na~obě strany (viz obrázek~\ref{sezins}).
 
-Pro~\textbf{smazání} prvku je ukazatel $k-1$ prvku přepsán na~prvek $k+1$. Pokud je mazán první prvek, změní se ukazatel na~seznam.
+Pro~\textbf{smazání} prvku je ukazatel \( k-1 \) prvku přepsán na~prvek \( k+1 \). Pokud je mazán první prvek, změní se ukazatel na~seznam.
 
 \textbf{Vyhledávat} lze dle indexu nebo podle dat. Seznam se postupně prochází dokud není nalezen prvek nebo konec seznamu.
 
@@ -273,7 +273,7 @@ Pro~\textbf{smazání} prvku je ukazatel $k-1$ prvku přepsán na~prvek $k+1$. P
 	\includegraphics[scale=0.5]{images/sezins.PNG}
 	\caption{Vkládání do~lineárního seznamu.}
 	\label{sezins}
-	
+
 	\includegraphics[scale=0.5]{images/sezinsfirst.PNG}
 	\caption{Vkládání do~lineárního seznamu na~první pozici. Ukazatel pole se~přepisuje na~první prvek a~ve vkládaném prvku se~přidá ukazatel na~předchozí první prvek.}
 
@@ -295,7 +295,7 @@ Dynamická datová struktura, kde se~odebírají prvky v~tom pořadí v~jakém b
 \clearpage
 \section{Abstraktní datový typ strom. Abstraktní datový typ binární strom. Úplný binární strom. Abstraktní datový typ binární vyhledávací strom (operace vložení, odstranění, smazání uzlu stromu). Průchody stromy in-order, pre-order, post-order.}
 
-\textbf{ADT typu strom} je nelineární dynamická abstraktní datová struktura. Každý uzel stromu může mít $n$ potomků a~zároveň má pouze jednoho předka. Nejčastější zástupci jsou obecný strom nebo $n$-ární strom. $n$-ární má maximální počet potomků rovný $n$, obecný strom není počtem potomků omezen. Skládá se~z~uzlů, které se~pojmenovávají:
+\textbf{ADT typu strom} je nelineární dynamická abstraktní datová struktura. Každý uzel stromu může mít \( n \) potomků a~zároveň má pouze jednoho předka. Nejčastější zástupci jsou obecný strom nebo \( n \)-ární strom. \( n \)-ární má maximální počet potomků rovný \( n \), obecný strom není počtem potomků omezen. Skládá se~z~uzlů, které se~pojmenovávají:
 
 \begin{itemize}
 	\item kořen, který existuje pouze jeden (pouze ve~vrcholu),
@@ -306,20 +306,20 @@ Dynamická datová struktura, kde se~odebírají prvky v~tom pořadí v~jakém b
 \begin{figure}[ht]
 	\centering
 	\begin{tikzpicture}[
-		sibling distance=6em,
-		every node/.style = {
-			draw,
-			shape=circle,
-			align=center,
-			top color=white,
-			bottom color=white
-		}
-	]
-	\node {kořen}
+			sibling distance=6em,
+			every node/.style = {
+					draw,
+					shape=circle,
+					align=center,
+					top color=white,
+					bottom color=white
+				}
+		]
+		\node {kořen}
 		child { node {list} }
 		child { node {uzel}
-			child { node {list}}
-			child { node {list}}};
+				child { node {list}}
+				child { node {list}}};
 	\end{tikzpicture}
 	\caption{Binární strom}
 \end{figure}
@@ -331,33 +331,35 @@ Binární strom je strom, který má nanejvýše dva potomky na~jeden uzel. Za~\
 
 \subsection{Binarní vyhledávací stromy}
 
-U~těchto stromů musí platit, že levá část potomků musí být vždy menší než kořen a~pravá část vždy vetší, tzn. prvky jsou seřazeny. Tyto stromy mohou být nevyvážené ale častěji se~také vyvažují, aby bylo dosaženo jejich optimální složitosti O($\log{n}$). Mohl by totiž nastat případ, kdy by ze~stromu vznikl pouze seznam (viz obrázek \ref{noneven_binary_tree} na~straně~\pageref{noneven_binary_tree}). U~vyvážených binárních stromů by rozdíl hloubky levé a~pravé části měl být 0 nebo 1.
+U~těchto stromů musí platit, že levá část potomků musí být vždy menší než kořen a~pravá část vždy vetší, tzn. prvky jsou seřazeny. Tyto stromy mohou být nevyvážené ale častěji se~také vyvažují, aby bylo dosaženo jejich optimální složitosti O(\( \log{n} \)). Mohl by totiž nastat případ, kdy by ze~stromu vznikl pouze seznam (viz obrázek \ref{noneven_binary_tree} na~straně~\pageref{noneven_binary_tree}). U~vyvážených binárních stromů by rozdíl hloubky levé a~pravé části měl být 0 nebo 1.
 
 \begin{figure}[ht]
 	\begin{minipage}[b]{0.47\textwidth}
 		\centering
 		\begin{tikzpicture}[
-			sibling distance=10em,
-			every node/.style = {shape=circle, draw, align=center, top color=white, bottom color=white}
-		]
-		\node {7}
+				sibling distance=10em,
+				every node/.style = {shape=circle, draw, align=center, top color=white, bottom color=white}
+			]
+			\node {7}
 			child { node {5} }
 			child { node {8}
-		};
+				};
 		\end{tikzpicture}
 		\caption{Vyvážený strom}
 		\label{even_binary_tree}
- 	\end{minipage}
+	\end{minipage}
 	\hspace*{1em}%
- 	\begin{minipage}[b]{0.47\textwidth}
- 		\centering
+	\begin{minipage}[b]{0.47\textwidth}
+		\centering
 		\begin{tikzpicture}[
-			sibling distance=10em, every node/.style = {shape=circle, draw, align=center, top color=white, bottom color=white}
-		]
-		\node {5}
+				sibling distance=10em, every node/.style = {shape=circle, draw, align=center, top color=white, bottom color=white}
+			]
+			\node {5}
 			child { node {7}
-		  		child { node {8} } 
-		  	};
+					child { node {8} }
+					child { node {8} }
+					child { node {8} }
+				};
 		\end{tikzpicture}
 		\caption{Nevyvážený strom}
 		\label{noneven_binary_tree}
@@ -388,9 +390,9 @@ Pro~pravý prvek (PL) nalezneme uzel, který je nejvíc napravo v~levém stromu 
 Strom a~výsledky procházení jsou na~obrázku \ref{tree}.
 
 \begin{enumerate}
-\item \textbf{Pre-order}. Nejprve se zpracuje kořen, poté levý podstrom a~nakonec pravý podstrom. Využívá se k~vytváření kopií stromů.
-\item \textbf{In-order}. Nejprve se zpracuje levý podstrom, poté kořen a~nakonec pravý podstrom. Výsledkem je seřazený seznam.
-\item \textbf{Post-order}. Nejprve je zpracován levý podstrom, poté pravý a~nakonec kořen. Využívá se k~mazání stromu od~listů ke~kořenu.
+	\item \textbf{Pre-order}. Nejprve se zpracuje kořen, poté levý podstrom a~nakonec pravý podstrom. Využívá se k~vytváření kopií stromů.
+	\item \textbf{In-order}. Nejprve se zpracuje levý podstrom, poté kořen a~nakonec pravý podstrom. Výsledkem je seřazený seznam.
+	\item \textbf{Post-order}. Nejprve je zpracován levý podstrom, poté pravý a~nakonec kořen. Využívá se k~mazání stromu od~listů ke~kořenu.
 \end{enumerate}
 
 \begin{figure}[ht]
@@ -407,9 +409,9 @@ Strom a~výsledky procházení jsou na~obrázku \ref{tree}.
 
 \clearpage
 \section[Problematika nevyvážených stromů. Vyvažování stromů AVL - rotace: jednoduchá levá, jednoduchá pravá, dvojitá levá, dvojitá pravá. Red-Black stromy]{Problematika nevyvážených stromů. Vyvažování stro-mů AVL -- rotace: jednoduchá levá, jednoduchá pravá, dvojitá levá, dvojitá pravá. Red-Black stromy.
-}
+ }
 
-Složitost u~nevyváženého stromu může klesnout z~O($\log{n}$) až na~O($n$), a~proto se stromy vyvažují. Vyvážený strom má rozdíl hloubky levého a~pravého podstromu rovnou vždy 0 nebo 1. Pokud má hloubku větší, označuje se za~nevyvážený a~z~pohledu problematiky by se~měl vyvážit například metodou AVL nebo Red-Black stromů.
+Složitost u~nevyváženého stromu může klesnout z~O(\( \log{n} \)) až na~O(\( n \)), a~proto se stromy vyvažují. Vyvážený strom má rozdíl hloubky levého a~pravého podstromu rovnou vždy 0 nebo 1. Pokud má hloubku větší, označuje se za~nevyvážený a~z~pohledu problematiky by se~měl vyvážit například metodou AVL nebo Red-Black stromů.
 
 \subsection{AVL stromy}
 
@@ -421,12 +423,12 @@ Vyvažuje se~dvěma typy rotace, u~kterých pak dále rozlišujeme stranu%
 \begin{figure}[ht]
 	\begin{minipage}[b]{0.47\textwidth}
 		\includegraphics[width=\textwidth]{images/Rotation1Type.JPG}
-		\caption{Rotace $\uparrow$ nebo $\downarrow$.}
+		\caption{Rotace \( \uparrow \) nebo \( \downarrow \).}
 	\end{minipage}
 	\hspace*{1em}%
 	\begin{minipage}[b]{0.47\textwidth}
 		\includegraphics[width=\textwidth]{images/Rotation2Type.JPG}
-		\caption{Rotace $\nearrow$ nebo $\nwarrow$.}
+		\caption{Rotace \( \nearrow \) nebo \( \nwarrow \).}
 	\end{minipage}
 \end{figure}
 
@@ -450,7 +452,7 @@ Nejsou tak dobře vyvážené jako AVL, ale řeší problém mnohonásobné rota
 
 \subsection{Hashovací tabulka}
 
-Hashovací tabulka spojuje klíč s~odpovídající hodnotou. Klíč je vypočítán z~obsahu položky tak, aby byl co nejjednoznačnější a~nedocházelo ke~kolizím; vše vychází z~pravděpodobnosti o~hashovacích funkcích. Využívají se~nejčastěji v~databázích nebo k~rychlému vyhledávaní v~polích. Paměťová složitost je O($n$).%
+Hashovací tabulka spojuje klíč s~odpovídající hodnotou. Klíč je vypočítán z~obsahu položky tak, aby byl co nejjednoznačnější a~nedocházelo ke~kolizím; vše vychází z~pravděpodobnosti o~hashovacích funkcích. Využívají se~nejčastěji v~databázích nebo k~rychlému vyhledávaní v~polích. Paměťová složitost je O(\( n \)).%
 \footnote{\url{https://courses.physics.illinois.edu/cs225/fa2020/resources/hashtable/}.}
 
 Při~\textbf{vkládání} se z~vkládaného prvku udělá hash. Tento hash se~přiřadí do~pole, na~místo, které mu odpovídá. Jestliže je místo obsazeno přiřadíme mu další volné místo dle algoritmu.
@@ -461,10 +463,10 @@ Při~\textbf{vkládání} se z~vkládaného prvku udělá hash. Tento hash se~p�
 	\centering
 	\caption{Časová složitost v~dobře a~špatně optimalizovaných tabulkách}
 	\begin{tabular}{|c||c|c|}\hline
-		operace   & průměrná & nejhorší \\\hline\hline
-		vkládání  & O(1)     & O($n$)   \\\hline
-		mazání    & O(1)     & O($n$)   \\\hline
-		vyhledání & O(1)     & O($n$)   \\\hline
+		operace   & průměrná & nejhorší   \\\hline\hline
+		vkládání  & O(1)     & O(\( n \)) \\\hline
+		mazání    & O(1)     & O(\( n \)) \\\hline
+		vyhledání & O(1)     & O(\( n \)) \\\hline
 	\end{tabular}
 \end{table}
 
@@ -481,14 +483,14 @@ Při~\textbf{vkládání} se z~vkládaného prvku udělá hash. Tento hash se~p�
 \begin{table}[ht]
 	\caption{Porovnání hashovací tabulky a~binárního stromu}
 	\begin{tabularx}{\textwidth}{|l||X|X|}\hline
-		ADT & Výhody & Nevýhody \\\hline\hline
-		binární strom & Rychlé vkládání, mazaní a~hledání (pokud je vyvažován) & Algoritmus mazání je časově náročný. \\\hline
-		AVL a~Red-black stromy & Stejné jako binární stromy, vyvažovány jsou vždy. & Jsou složité. \\\hline
-		hashovací tabulka & Rychlé vkládání, při~existenci klíče rychlé vyhledávání. & Pomalý přístup pokud klíč není nalezen. Neefektivní využití paměti. \\\hline
+		ADT                    & Výhody                                                   & Nevýhody                                                            \\\hline\hline
+		binární strom          & Rychlé vkládání, mazaní a~hledání (pokud je vyvažován)   & Algoritmus mazání je časově náročný.                                \\\hline
+		AVL a~Red-black stromy & Stejné jako binární stromy, vyvažovány jsou vždy.        & Jsou složité.                                                       \\\hline
+		hashovací tabulka      & Rychlé vkládání, při~existenci klíče rychlé vyhledávání. & Pomalý přístup pokud klíč není nalezen. Neefektivní využití paměti. \\\hline
 	\end{tabularx}
 \end{table}
 
-Hashovací tabulka je rychlejší na~vyhledávání pokud je dobře napsána hashovací funkce, ve~špatném případě lze dojít ke~složitosti O($n$). Nelze vyhledávat pokud máme jen částečný klíč nebo potřebujeme v~nějakém intervalu. Další nevýhodou je složitost vytvoření hashovacích tabulek oproti stromu.
+Hashovací tabulka je rychlejší na~vyhledávání pokud je dobře napsána hashovací funkce, ve~špatném případě lze dojít ke~složitosti O(\( n \)). Nelze vyhledávat pokud máme jen částečný klíč nebo potřebujeme v~nějakém intervalu. Další nevýhodou je složitost vytvoření hashovacích tabulek oproti stromu.
 
 \clearpage
 \section{Jednoduché a~pokročilejší řadící techniky a~jejich srovnání. Stabilita řadícího algoritmu. Bubble sort. Insertion sort. Selection sort. Shell sort. Merge sort. Heap sort. Quick sort.}
@@ -505,7 +507,7 @@ Hashovací tabulka je rychlejší na~vyhledávání pokud je dobře napsána has
 
 \subsection{Porovnání algoritmů}
 
-Třídění pomocí algoritmů Bubble Sort, Insert Sort a~Select Sort má složitost O($n^2$). Algoritmus Quick Sort má složitost $\Theta$($n\log{n}$), kdy v~nejhorším případě může nabývat až O($n^2$). Algoritmus Merge Sort má složitost O($n\log{n}$).
+Třídění pomocí algoritmů Bubble Sort, Insert Sort a~Select Sort má složitost O(\( n^2 \)). Algoritmus Quick Sort má složitost \( \Theta \)(\( n\log{n} \)), kdy v~nejhorším případě může nabývat až O(\( n^2 \)). Algoritmus Merge Sort má složitost O(\( n\log{n} \)).
 
 \subsection{Stabilita řízení}
 
@@ -515,29 +517,29 @@ Když je řazen seznam osob dle křestního jména a~poté příjmení, stabiln�
 
 \subsection{Bubble sort}
 
-Je jednoduchý stabilní řadící algoritmus se~složitostí O($n^2$).
+Je jednoduchý stabilní řadící algoritmus se~složitostí O(\( n^2 \)).
 
 Porovnávají se~dva sousední prvky, pokud je nižší číslo nalevo od~vyššího tak se~prohodí. A tak probublávají postupně dokud se~neseřadí. Pokud jsou čísla v~průběhu už správně seřazena tak je neprohodí ale postupuje dále.%
 \footnote{Animace Bubble sort: \url{https://www.algoritmy.net/article/3/Bubble-sort}.}
 
 \subsection{Insertion sort}
 
-Je jednoduchý stabilní řadící algoritmus se~složitostí O($n^2$). Množina prvků je rozdělena na~seřazenou (na~počátku prázdnou) a~neseřazenou část. Prvky se jeden po~druhém přesouvají z~neseřazené části a~jsou umísťovány do~seřazené na~správné místo.%
+Je jednoduchý stabilní řadící algoritmus se~složitostí O(\( n^2 \)). Množina prvků je rozdělena na~seřazenou (na~počátku prázdnou) a~neseřazenou část. Prvky se jeden po~druhém přesouvají z~neseřazené části a~jsou umísťovány do~seřazené na~správné místo.%
 \footnote{Animace Insertion sort: \url{https://www.algoritmy.net/article/8/Insertion-sort}.}
 
 \subsection{Selection sort}
 
-Je jednoduchý nestabilní řadící algoritmus se~složitostí O($n^2$). Množina prvků je rozdělena na~seřazenou (na~počátku prázdnou) a~seřazenou část. V~neseřazené části je nalezen prvek s~nejvyšší hodnotou a~je umístěn do~seřazené části. Poté je nalezen druhý největší prvek a~je umístěn do~seřazené.%
+Je jednoduchý nestabilní řadící algoritmus se~složitostí O(\( n^2 \)). Množina prvků je rozdělena na~seřazenou (na~počátku prázdnou) a~seřazenou část. V~neseřazené části je nalezen prvek s~nejvyšší hodnotou a~je umístěn do~seřazené části. Poté je nalezen druhý největší prvek a~je umístěn do~seřazené.%
 \footnote{Animace Selection sort: \url{https://www.algoritmy.net/article/4/Selection-sort}.}
 
 \subsection{Shell sort}
 
-Je nestabilní kvadratický řadící algoritmus se~složitostí O($n^2$). Funguje na~principu insertion sort. Nejprve seřadí prvky, mezi kterými je určitá mezera (první a~pátý, pátý a~devátý, druhý a~šestý) a~v~každém kroku je~tato mezera zmenšena; když je snížena na~1, dojde k~degradaci na~bežný insertion sort.%
+Je nestabilní kvadratický řadící algoritmus se~složitostí O(\( n^2 \)). Funguje na~principu insertion sort. Nejprve seřadí prvky, mezi kterými je určitá mezera (první a~pátý, pátý a~devátý, druhý a~šestý) a~v~každém kroku je~tato mezera zmenšena; když je snížena na~1, dojde k~degradaci na~bežný insertion sort.%
 \footnote{Animace Shell sort: \url{https://www.algoritmy.net/article/154/Shell-sort}.}
 
 \subsection{Merge sort}
 
-Je stabilní složitý řadící algoritmus se~složitostí O($n\log{n}$).
+Je stabilní složitý řadící algoritmus se~složitostí O(\( n\log{n} \)).
 
 Nesetříděné pole je děleno na~poloviny, dokud nová pole nemají velikost 1. Poté se skládají dohromady: porovná se první prvek z~pole A s~prvním prvkem pole~B a~seřadí se, porovná se druhý prvek z~pole A s~druhým prvkem pole B, seřadí se a~umístí za~první prvky. Tento proces je~opakován dokud nejspou spojeny všechny prvky původního pole.%
 \footnote{Video Merge sort: \url{https://www.youtube.com/watch?v=qdv3i6X0PiQ}.}
@@ -550,14 +552,14 @@ Nesetříděné pole je děleno na~poloviny, dokud nová pole nemají velikost 1
 
 \subsection{Heap sort}
 
-Je nestabilní složitý řadící algoritmus se~složitostí O($n\log{n}$). Je jeden z~nejefektivnějších řadících algoritmů.
+Je nestabilní složitý řadící algoritmus se~složitostí O(\( n\log{n} \)). Je jeden z~nejefektivnějších řadících algoritmů.
 
 Funguje na~principu prioritní fronty (stromová struktura). Nejprve je~prvky naplněn binární strom. Z~tohoto stromu je~vytvořena binární halda průchodem BFS. Z~binárního stromu je kořen umístěn do~množiny seřazených prvků; kořen stromu je~umístěn do~seřazené části, na~jeho místo je umístěn nejnižší list a~strom je znovu seřazen. Nový kořen stromu je~znovu umístěn do~seřazené části a~takto se algoritmus opakuje dokud ve~stromu zbývají uzly.%
 \footnote{Video Heap sort: \url{https://www.youtube.com/watch?v=LbB357_RwlY}.}
 
 \subsection{Quick sort}
 
-Je nestabilní složitý řadící algoritmus se~složitostí O($n^2$), resp. $\Theta$($n\log{n}$).
+Je nestabilní složitý řadící algoritmus se~složitostí O(\( n^2 \)), resp. \( \Theta \)(\( n\log{n} \)).
 
 Je vybrán pivot (špatným výběrem lze složitost zhoršit; často bývá vybrán střed). Všechny prvky menší než~pivot se přesunou nalevo a~větší napravo. V~obou polovinách je vybrán nový pivot v~jejich středu a~algoritmus se rekurzivně opakuje. Pivot vždy zůstává na~místě a~je považován za~setříděný.%
 \footnote{Video Quick sort: \url{https://www.youtube.com/watch?v=ZHVk2blR45Q}.}
@@ -567,7 +569,7 @@ Je vybrán pivot (špatným výběrem lze složitost zhoršit; často bývá vyb
 
 \subsection{Graf a~teorie grafů}
 
-Graf je definován jako uspořádaná dvojice množiny vrcholů $V$~a~množin hran $E$ ($G(V,E)$), kde vrcholy (\emph{vertices/nodes}) jsou uzly grafu a~hrany (\emph{edges}) jsou spoje mezi vrcholy. Graf může být jakýkoliv rovinný nebo prostorový útvar, který bude znázorňovat důležité vazby mezi důležitými prvky (vrcholy).
+Graf je definován jako uspořádaná dvojice množiny vrcholů \( V \)~a~množin hran \( E \) (\( G(V,E) \)), kde vrcholy (\emph{vertices/nodes}) jsou uzly grafu a~hrany (\emph{edges}) jsou spoje mezi vrcholy. Graf může být jakýkoliv rovinný nebo prostorový útvar, který bude znázorňovat důležité vazby mezi důležitými prvky (vrcholy).
 
 \textbf{Hrana} znázorňuje vztah mezi vrcholy. Rozlišujeme na~hrany orientované a~neorientované. U~orientovaných lze stanovit počáteční a~koncový vrchol a~u neorientovaného to nelze. Hrany lze ohodnotit, kdy hodnota může například představovat délku, zátěž atd.
 
@@ -604,7 +606,7 @@ Graf je definován jako uspořádaná dvojice množiny vrcholů $V$~a~množin hr
 
 \subsection{Slepé prohledávání}
 
-\textbf{BFS} využívá frontu do~které nejprve vloží vstupní vrchol. Z~tohoto vrcholu se~vezmou všichni sousedé a~vloží se~do~fronty, z~které se~bere postupně a~jejich sousedé se~přidávají do~fronty. Při~tomto se~každá už navštívený vrchol ukládá do~nějakého pole/seznamu navštívených abychom ho nenavštěvovali znovu.%
+\textbf{BFS} využívá frontu do~které nejprve vloží vstupní vrchol. Z~tohoto vrcholu se~vezmou všichni sousedé a~vloží se~do~fronty, z~které se~bere postupně a~jejich sousedé se~přidávají do~fronty. Při~tomto se~každý už navštívený vrchol ukládá do~nějakého pole/seznamu navštívených abychom ho nenavštěvovali znovu.%
 \footnote{Video BFS: \url{https://www.youtube.com/watch?v=oDqjPvD54Ss}.}
 
 \textbf{DFS}\,--\,pracuje na~principu, že prozkoumává prvně vrchol na~jednu stranu a~v ní pokračuje dokud nedojde na~konec nebo nedorazí do~už navštíveného vrcholu. Využívá zásobník.%
@@ -645,7 +647,7 @@ Optimalizace a~jejími úlohami se~setkáváme při~řešení praktických úloh
 
 Je jeden ze~způsobů optimalizace. Byly vytvořeny aby sjednotily optimalizační metody co využívají \enquote{evoluční} principy. Evoluční algoritmy zastřešují řadu přístupů využívajících modely biologické evoluce. Tyto modely jsou: přirozený výběr (výběr silnějšího jedince, podle fitness funkce), náhodný genetický drift (mutace, decimuje jedince s~vysokou fitness) a~reprodukční proces (křížení jedinců). Spadají zde přístupy jako genetické algoritmy, genetické programovaní, evoluční strategie, evoluční programovaní.
 
-Obecný evoluční algoritmus začíná s~základní populací. Z~této populace se vytvoří výběr jedinců, které se zříží. Tito jedinci následně zmutují a~vytvoří novou populaci. Tyto kroky se~opakují v~$N$ iteracích. Ukončení je stanoveno předem: počtem iterací, dosažení požadovaného jedince, minimální změnou fitness populace po~několik iterací.
+Obecný evoluční algoritmus začíná s~základní populací. Z~této populace se vytvoří výběr jedinců, které se zříží. Tito jedinci následně zmutují a~vytvoří novou populaci. Tyto kroky se~opakují v~\( N \) iteracích. Ukončení je stanoveno předem: počtem iterací, dosažení požadovaného jedince, minimální změnou fitness populace po~několik iterací.
 
 \subsection{Genetické algoritmy}
 
@@ -667,9 +669,9 @@ Hledá samotnou funkci a~ne její parametry. Oproti GA se~liší v~reprezentaci 
 
 \textbf{Chromozom} je řetězec tvořený geny. Má za~úkol odlišovat se od~zbytku populace (DNA). Lze ho kódovat binárně, reálnými čísly, znaky, objekty, \dots
 
-\textbf{Gen} na $i$-té pozici reprezentuje stejnou charakteristiku v~každém jedinci.
+\textbf{Gen} na \( i \)-té pozici reprezentuje stejnou charakteristiku v~každém jedinci.
 
-\textbf{Alela} je hodnota kterou může nabývat gen (např $\{0, 1\}$).
+\textbf{Alela} je hodnota kterou může nabývat gen (např \( \{0, 1\} \)).
 
 \textbf{Fitness funkce} kvantitativně vyjadřuje kvalitu každého řešení, např. dosažení požadované přesnosti algoritmu, množství času potřebné pro~výpočet algoritmu, množství chyb mezi skutečným a~požadovaným výstupem. Je více druhů metod vytvoření fitness funkce: hrubá, standardizovaná, přizpůsobená, normalizovaná.
 
@@ -677,7 +679,7 @@ Hledá samotnou funkci a~ne její parametry. Oproti GA se~liší v~reprezentaci 
 
 \textbf{Selekce ruletový výběr, varianta 2}: jedinci jsou seřazeni vzestupně podle hodnoty fitness a~velikost místa je určena rovnicí. Tímto se~potlačují nadprůměrní jedinci, kteří by negativně ovlivňovali další generace.
 
-\textbf{Selekce turnajový výběr}: náhodně se~vybere $n$ jedinců a~postupným porovnáváním je vybrán nejlepší.
+\textbf{Selekce turnajový výběr}: náhodně se~vybere \( n \) jedinců a~postupným porovnáváním je vybrán nejlepší.
 
 \subsection{Metody křížení}
 
@@ -691,7 +693,7 @@ Napodobují genetickou evoluci a~pomáhají ve~vývoji. Čtyři základní metod
 
 	\includegraphics[scale=0.55]{images/1bod.PNG}
 	\includegraphics[scale=0.55]{images/2bod.PNG}
-	\caption{\textbf{n-bodové křížení} dělí genotyp v~$n$ bodech.}
+	\caption{\textbf{n-bodové křížení} dělí genotyp v~\( n \) bodech.}
 	\label{1bod2bod}
 
 	\includegraphics[scale=0.7]{images/uniform.PNG}
@@ -715,17 +717,17 @@ Sériové výpočty běží na~jediném CPU s~použitím jednoho vlánka, kde je
 	\includegraphics[scale=0.7]{images/serialComputing.JPG}
 	\hspace*{1em}
 	\includegraphics[scale=0.7]{images/parallelComputing.JPG}
-	
+
 	\caption{Sériové a~paralelní výpočty}
 \end{figure}
 
 Veškeré paralelní výpočty lze provádět sekvenčně, ale ne všechny sekvenční algoritmy lze paralelizovat. Příklady výpočetních zdrojů:
 \begin{itemize}
 	\item Počítač s~několika procesory
-	\begin{itemize}
-		\item Multiprocesor se~sdílenou pamětí (propojení více procesorů dohromady)
-		\item Multiprocesor obsahující několik procesorů (jader) na~jednom čipu (obyčejné CPU).
-	\end{itemize}
+	      \begin{itemize}
+		      \item Multiprocesor se~sdílenou pamětí (propojení více procesorů dohromady)
+		      \item Multiprocesor obsahující několik procesorů (jader) na~jednom čipu (obyčejné CPU).
+	      \end{itemize}
 	\item Libovolný počet počítačů propojený počítačovou sítí (Cluster computer)
 	\item Spojení výše uvedeného do~jednoho systému.
 \end{itemize}
@@ -739,10 +741,10 @@ Modely dělíme hlavně dle Flynnovy klasifikace z~dvou hledisek: toku instrukc�
 	\caption{Modely dle Flynnovy klasifikace}
 
 	\begin{tabular}{c|cc}
-	{}            & Single Intruction & Multiple Instructions \\
-	\hline
-	Single Data   & sériový           & paralelní             \\
-	Multiple Data & paralelní         & paralelní             \\
+		{}            & Single Intruction & Multiple Instructions \\
+		\hline
+		Single Data   & sériový           & paralelní             \\
+		Multiple Data & paralelní         & paralelní             \\
 	\end{tabular}
 \end{table}
 

--- a/BPC-ZSY/main.tex
+++ b/BPC-ZSY/main.tex
@@ -69,7 +69,7 @@
     urlcolor=blue
 }
 \usetikzlibrary{shapes,arrows}     % tikz rozšíření
-\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu 
+\usemintedstyle{pastie}            % nastavení vzhledu syntax highlightingu
                                         %(musí být odkomentované přidání balíčku minted)
 
 \newenvironment{code}{\captionsetup{type=listing}}{}


### PR DESCRIPTION
Formatting was done automatically with `latexindent`, switch to `\(  ... \)` from `$ ... $` was purely because ChkTeX wouldn't shut up about it.